### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Library for Ocean Controls KTA-259v3 Thermocouple Shield
 category=Sensors
 url=https://github.com/andygock/KTA259V3
 architectures=avr
-includes=
+includes=KTA259V3.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > KTA259V3**. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format